### PR TITLE
Fallback to console email backend when SMTP is not configured

### DIFF
--- a/legalize_site/legalize_site/settings.py
+++ b/legalize_site/legalize_site/settings.py
@@ -140,11 +140,21 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 # ==== ПОЧТА (Brevo SMTP) ====
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp-relay.brevo.com")
 EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
 EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "true").lower() in ("1", "true", "yes", "on")
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")              # ваш SMTP login из Brevo (без пробелов)
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")      # SMTP key из Brevo
-DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)
+
+_DEFAULT_SMTP_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
+if not EMAIL_BACKEND:
+    if EMAIL_HOST_USER and EMAIL_HOST_PASSWORD:
+        EMAIL_BACKEND = _DEFAULT_SMTP_BACKEND
+    else:
+        # В режиме разработки (без настроенного SMTP) выводим письма в консоль,
+        # чтобы формы сброса пароля не падали с 500 ошибкой.
+        EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL") or EMAIL_HOST_USER or "webmaster@localhost"
 SERVER_EMAIL = DEFAULT_FROM_EMAIL

--- a/legalize_site/portal/templatetags/form_filters.py
+++ b/legalize_site/portal/templatetags/form_filters.py
@@ -1,0 +1,10 @@
+"""Backward-compatible alias for the legacy ``form_filters`` template tag library."""
+
+from django import template
+
+from .portal_filters import add_class, add_placeholder
+
+register = template.Library()
+
+register.filter("add_class", add_class)
+register.filter("add_placeholder", add_placeholder)

--- a/legalize_site/templates/account/password_reset.html
+++ b/legalize_site/templates/account/password_reset.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load form_filters %}
+{% load portal_filters %}
 
 {% block title %}{% translate "Сброс пароля" %}{% endblock %}
 

--- a/legalize_site/templates/account/password_reset_from_key.html
+++ b/legalize_site/templates/account/password_reset_from_key.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load form_filters %}
+{% load portal_filters %}
 
 {% block title %}{% translate "Новый пароль" %}{% endblock %}
 

--- a/legalize_site/templates/socialaccount/signup.html
+++ b/legalize_site/templates/socialaccount/signup.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load form_filters %}
+{% load portal_filters %}
 
 {% block head_title %}{% trans "Signup" %}{% endblock %}
 


### PR DESCRIPTION
## Summary
- fallback to Django's console email backend whenever SMTP credentials are not provided so password reset can run locally without a 500 error
- keep the Brevo SMTP settings for deployments that provide explicit credentials while ensuring sensible default sender addresses

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68e412b8d7e8832e8983dafc31652002