### PR TITLE
Translation Studio: superuser-only menu, mac shortcut support, UI badge, and logging

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -114,11 +114,13 @@
                     <i class="bi bi-speedometer2 me-2"></i>{% translate "Метрики" %}
                   </a>
                 </li>
+                {% if user.is_superuser %}
                 <li>
                   <a class="dropdown-item fw-bold" href="{% url 'translations:dashboard' %}" style="color: #6366f1;">
                     <i class="bi bi-translate me-2"></i>Translation Studio
                   </a>
                 </li>
+                {% endif %}
                 <li><hr class="dropdown-divider"></li>
                 {% endif %}
                 <li>

--- a/translations/static/translations/js/translation_overlay.js
+++ b/translations/static/translations/js/translation_overlay.js
@@ -10,8 +10,13 @@
         get: studioConfig.getUrl || '/studio/get-api/',
         scan: studioConfig.scanUrl || '/studio/scan-api/'
     };
+    const STUDIO_SHORTCUT_HINT = '⌘/Ctrl+Shift+Click or Alt+Shift+Click';
     const STUDIO_TARGET_SELECTOR = '.studio-editable, .studio-clickable-container, .studio-form-control';
     const normalizeText = (s) => (s || "").replace(/\s+/g, ' ').trim();
+    const isStudioModifierClick = (event) => {
+        if (!event) return false;
+        return Boolean(event.shiftKey && (event.ctrlKey || event.metaKey || event.altKey));
+    };
 
     // Only initialize if we see editable elements or markers
     let activeElement = null;
@@ -239,7 +244,7 @@
     // (some browsers trigger new-tab navigation on modifier+click). We handle
     // mousedown in capture phase and open the studio there to avoid navigation.
     document.addEventListener('mousedown', function(e) {
-        if ((e.ctrlKey && e.shiftKey) || (e.altKey && e.shiftKey)) {
+        if (isStudioModifierClick(e)) {
             const x = e.clientX, y = e.clientY;
             // Quick nearest-element search using elementFromPoint first
             try {
@@ -295,9 +300,9 @@
         }
     }, true);
 
-    // Handle Ctrl+Shift or Alt+Shift + Click (Alt+Shift added for convenience)
+    // Handle Cmd/Ctrl+Shift or Alt+Shift + Click.
     document.addEventListener('click', function(e) {
-        if ((e.ctrlKey && e.shiftKey) || (e.altKey && e.shiftKey)) {
+        if (isStudioModifierClick(e)) {
             // If we just opened the studio on mousedown, ignore the subsequent click
             if (Date.now() - lastStudioOpenAt < 500) {
                 try { e.preventDefault(); } catch(_) {}
@@ -496,9 +501,26 @@
     // Modern Lavender/Blue Highlight Styling
     const style = document.createElement('style');
     style.innerHTML = `
+        #studio-mode-indicator {
+            position: fixed;
+            right: 14px;
+            bottom: 14px;
+            z-index: 9999998;
+            background: rgba(79, 70, 229, 0.96);
+            color: #fff;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.01em;
+            padding: 8px 12px;
+            box-shadow: 0 8px 24px rgba(30, 41, 59, 0.25);
+            backdrop-filter: blur(4px);
+        }
         .studio-editable {
             transition: all 0.3s ease;
             position: relative;
+            text-decoration: underline dotted rgba(99, 102, 241, 0.45);
+            text-underline-offset: 2px;
         }
         .studio-editable:hover {
             background-color: rgba(99, 102, 241, 0.08);
@@ -553,6 +575,13 @@
         }
     `;
     document.head.appendChild(style);
+
+    if (!document.getElementById('studio-mode-indicator')) {
+        const badge = document.createElement('div');
+        badge.id = 'studio-mode-indicator';
+        badge.innerText = `Studio mode ON · ${STUDIO_SHORTCUT_HINT}`;
+        document.body.appendChild(badge);
+    }
 
     // Deep Fix: Convert [[i18n:...]] to Spans on the fly if middleware missed them
     // or if they are loaded dynamically via partials

--- a/translations/tests/test_views_and_middleware.py
+++ b/translations/tests/test_views_and_middleware.py
@@ -69,13 +69,19 @@ class TranslationViewsTests(TestCase):
         self.client.login(email="super@example.com", password="pass")
         url = reverse("translations:toggle_studio")
 
-        response_1 = self.client.get(url, HTTP_REFERER="/staff/")
+        from unittest.mock import patch
+
+        with patch("translations.views.logger.info") as info_mock:
+            response_1 = self.client.get(url, HTTP_REFERER="/staff/")
         self.assertEqual(response_1.status_code, 302)
         self.assertTrue(self.client.session.get("studio_mode"))
+        self.assertIn("ENABLED", info_mock.call_args_list[0].args)
 
-        response_2 = self.client.get(url, HTTP_REFERER="/staff/")
+        with patch("translations.views.logger.info") as info_mock:
+            response_2 = self.client.get(url, HTTP_REFERER="/staff/")
         self.assertEqual(response_2.status_code, 302)
         self.assertFalse(self.client.session.get("studio_mode"))
+        self.assertIn("DISABLED", info_mock.call_args_list[0].args)
 
     def test_staff_page_does_not_load_overlay_without_studio_mode(self):
         self.client.login(email="super@example.com", password="pass")
@@ -106,6 +112,17 @@ class TranslationViewsTests(TestCase):
         response = self.client.get(reverse("translations:dashboard"))
 
         self.assertEqual(response.status_code, 302)
+
+    def test_studio_menu_item_is_visible_only_for_superusers(self):
+        self.client.login(email="staff@example.com", password="pass")
+        staff_response = self.client.get(reverse("clients:client_list"))
+        self.assertEqual(staff_response.status_code, 200)
+        self.assertNotIn("Translation Studio", staff_response.content.decode("utf-8"))
+
+        self.client.login(email="super@example.com", password="pass")
+        superuser_response = self.client.get(reverse("clients:client_list"))
+        self.assertEqual(superuser_response.status_code, 200)
+        self.assertIn("Translation Studio", superuser_response.content.decode("utf-8"))
 
     def test_scan_api_returns_mapping_for_all_languages(self):
         self.client.login(email="super@example.com", password="pass")
@@ -192,6 +209,8 @@ class TranslationOverlayScriptTests(TestCase):
         self.assertIn("studio-clickable-container", content)
         self.assertIn("const childTarget = el.querySelector('.studio-editable, .studio-form-control');", content)
         self.assertIn("let activeLookupKeys = new Set();", content)
+        self.assertIn("event.metaKey", content)
+        self.assertIn("STUDIO_SHORTCUT_HINT", content)
+        self.assertIn("studio-mode-indicator", content)
         self.assertIn("function syncStudioTargetIds(root = document.body)", content)
         self.assertIn("function updateLiveTranslations(msgid, translatedText)", content)
-

--- a/translations/views.py
+++ b/translations/views.py
@@ -53,7 +53,14 @@ def update_translation_api(request):
 def toggle_studio_mode(request):
     """Turn on/off the in-context editing spans."""
     current = request.session.get('studio_mode', False)
-    request.session['studio_mode'] = not current
+    next_state = not current
+    request.session['studio_mode'] = next_state
+    logger.info(
+        "Translation Studio mode %s by user=%s referer=%s",
+        "ENABLED" if next_state else "DISABLED",
+        getattr(request.user, "email", getattr(request.user, "pk", None)),
+        request.META.get("HTTP_REFERER"),
+    )
     return redirect(request.META.get('HTTP_REFERER', '/'))
 
 @user_passes_test(is_superuser)
@@ -113,4 +120,3 @@ def scan_translations_api(request):
                 mapping[normalize(val)] = msgid
 
     return JsonResponse({'status': 'ok', 'data': mapping})
-


### PR DESCRIPTION
### Motivation
- Limit access to the in-context Translation Studio UI to superusers and improve observability and UX for in-browser editing.
- Make the overlay activation shortcut more robust across platforms by supporting the Mac `Meta` key in addition to Ctrl/Alt modifiers.
- Provide a persistent on-screen indicator and subtle styling updates so users know Studio mode is active.

### Description
- Restrict the "Translation Studio" nav menu item in `templates/base.html` to only render when `user.is_superuser` is true.
- Add explicit logging in `translations/views.py`'s `toggle_studio_mode` to record when Studio mode is `ENABLED` or `DISABLED` along with the acting user and referer.
- Improve the overlay script `translations/static/translations/js/translation_overlay.js` by adding `STUDIO_SHORTCUT_HINT`, a helper `isStudioModifierClick` that recognizes `event.metaKey` (Cmd) and existing modifiers, a persistent `#studio-mode-indicator` badge, and visual styling tweaks for `.studio-editable` elements.
- Update tests in `translations/tests/test_views_and_middleware.py` to assert logging during toggle, to validate the menu item visibility is superuser-only, and to check the overlay script includes the new shortcut/metaKey and indicator strings.

### Testing
- Ran the translations unit tests via `python manage.py test translations`; all modified `TranslationViewsTests` and `TranslationOverlayScriptTests` passed.
- Verified `TranslationViewsTests.test_toggle_studio_mode_flips_session_flag` now asserts `logger.info` is called with `ENABLED`/`DISABLED` and the test passed.
- Verified `TranslationViewsTests.test_studio_menu_item_is_visible_only_for_superusers` and `TranslationOverlayScriptTests.test_overlay_script_reads_runtime_url_config` were added/updated and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8bccf8c98832ea573d6eea829bb74)