### PR TITLE
Restore missing role constants to fix import error on startup

### DIFF
--- a/clients/services/roles.py
+++ b/clients/services/roles.py
@@ -25,6 +25,9 @@ EMAIL_MUTATION_ROLES = ("Admin", "Manager")
 EXPORT_MUTATION_ROLES = ("Admin", "Manager")
 REPORT_MUTATION_ROLES = ("Admin", "Manager")
 TRANSLATION_ALLOWED_ROLES = ("Admin", "Translator")
+CLIENT_EDIT_ROLES = CLIENT_MUTATION_ROLES
+CLIENT_DELETE_ROLES = ("Admin", "Manager")
+CHECKLIST_MANAGE_ROLES = DOCUMENT_MUTATION_ROLES
 
 
 def user_has_any_role(user: AbstractBaseUser, *role_names: str) -> bool:


### PR DESCRIPTION
### Motivation
- Django app startup failed with an `ImportError` because `clients.views.clients` imports role constants that were missing from `clients.services.roles`, preventing URL configuration from loading.

### Description
- Added compatibility constants to `clients/services/roles.py`: `CLIENT_EDIT_ROLES = CLIENT_MUTATION_ROLES`, `CLIENT_DELETE_ROLES = ("Admin", "Manager")`, and `CHECKLIST_MANAGE_ROLES = DOCUMENT_MUTATION_ROLES` so views can import them at module load time.

### Testing
- Ran `python manage.py check`, which completed (only existing environment warnings reported) and the command exited successfully.
- Ran `pytest -q clients/tests/test_roles_constants.py`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed201b3dac832e833e7a5e099294f3)