### PR TITLE
Fix permissions, cleanup_email_logs bug, and translation/build defaults

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,5 @@ pip install -r requirements.txt
 # Skip translating files shipped in the virtualenv to avoid permission errors
 python manage.py compilemessages --ignore "venv" --ignore ".venv"
 
-# Запуск тестов перед сборкой статики
-DJANGO_SETTINGS_MODULE=legalize_site.settings.test pytest --maxfail=1 -q || exit 1
+# Tests run in GitHub Actions; production build skips pytest for faster deploys.
 python manage.py collectstatic --no-input

--- a/clients/management/commands/cleanup_email_logs.py
+++ b/clients/management/commands/cleanup_email_logs.py
@@ -24,7 +24,6 @@ class Command(BaseCommand):
         campaign_count = EmailCampaign.objects.filter(created_at__lt=cutoff).exclude(message="").update(
             message="",
             recipient_emails="[]",
-            recipient_emails=[],
             error_details="",
         )
 

--- a/clients/services/roles.py
+++ b/clients/services/roles.py
@@ -19,6 +19,8 @@ PEOPLE_ALLOWED_ROLES = ("Admin",)
 
 CLIENT_MUTATION_ROLES = ("Admin", "Manager", "Staff")
 DOCUMENT_MUTATION_ROLES = ("Admin", "Manager", "Staff")
+DOCUMENT_EDIT_ROLES = ("Admin", "Manager", "Staff")
+DOCUMENT_DELETE_ROLES = ("Admin", "Manager")
 TASK_MUTATION_ROLES = ("Admin", "Manager", "Staff")
 PAYMENT_MUTATION_ROLES = ("Admin", "Manager")
 EMAIL_MUTATION_ROLES = ("Admin", "Manager")
@@ -27,7 +29,7 @@ REPORT_MUTATION_ROLES = ("Admin", "Manager")
 TRANSLATION_ALLOWED_ROLES = ("Admin", "Translator")
 CLIENT_EDIT_ROLES = CLIENT_MUTATION_ROLES
 CLIENT_DELETE_ROLES = ("Admin", "Manager")
-CHECKLIST_MANAGE_ROLES = DOCUMENT_MUTATION_ROLES
+CHECKLIST_MANAGE_ROLES = ("Admin", "Manager")
 
 
 def user_has_any_role(user: AbstractBaseUser, *role_names: str) -> bool:

--- a/clients/tests/test_role_permissions_stage14.py
+++ b/clients/tests/test_role_permissions_stage14.py
@@ -7,7 +7,10 @@ from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
 
-from clients.models import Client, Payment
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from clients.constants import DocumentType
+from clients.models import Client, Document, DocumentRequirement, Payment
 from clients.services.roles import ensure_predefined_roles
 
 
@@ -35,6 +38,18 @@ class RolePermissionMatrixTests(TestCase):
             assigned_staff=self.staff,
         )
         self.payment = Payment.objects.create(client=self.client_obj, total_amount=10, amount_paid=0, service_description="consultation", payment_method="cash")
+        self.document = Document.objects.create(
+            client=self.client_obj,
+            document_type=DocumentType.PASSPORT.value,
+            file=SimpleUploadedFile("passport-stage14.pdf", b"passport", content_type="application/pdf"),
+        )
+        self.requirement = DocumentRequirement.objects.create(
+            application_purpose=self.client_obj.application_purpose,
+            document_type=DocumentType.PASSPORT.value,
+            custom_name="Passport requirement",
+            position=0,
+            is_required=True,
+        )
 
     def test_readonly_cannot_mutate_client_data(self):
         self.client.force_login(self.read_only)
@@ -52,6 +67,86 @@ class RolePermissionMatrixTests(TestCase):
         self.assertEqual(self.client.get(reverse("clients:client_export_zip", kwargs={"pk": self.client_obj.pk})).status_code, 403)
         self.assertEqual(self.client.post(reverse("clients:send_custom_email", kwargs={"pk": self.client_obj.pk})).status_code, 403)
         self.assertEqual(self.client.post(reverse("clients:edit_payment", kwargs={"payment_id": self.payment.pk})).status_code, 403)
+
+    def test_staff_cannot_delete_client(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(reverse("clients:client_delete", kwargs={"pk": self.client_obj.pk}))
+        self.assertEqual(response.status_code, 403)
+
+    def test_manager_can_delete_client(self):
+        self.client.force_login(self.manager)
+        response = self.client.post(reverse("clients:client_delete", kwargs={"pk": self.client_obj.pk}))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Client.objects.filter(pk=self.client_obj.pk).exists())
+
+    def test_admin_can_delete_client(self):
+        self.client.force_login(self.admin)
+        response = self.client.post(reverse("clients:client_delete", kwargs={"pk": self.client_obj.pk}))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Client.objects.filter(pk=self.client_obj.pk).exists())
+
+    def test_staff_cannot_delete_document(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(reverse("clients:document_delete", kwargs={"pk": self.document.pk}))
+        self.assertEqual(response.status_code, 403)
+
+    def test_manager_can_delete_document(self):
+        self.client.force_login(self.manager)
+        response = self.client.post(reverse("clients:document_delete", kwargs={"pk": self.document.pk}))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Document.objects.filter(pk=self.document.pk).exists())
+
+    def test_admin_can_delete_document(self):
+        self.client.force_login(self.admin)
+        response = self.client.post(reverse("clients:document_delete", kwargs={"pk": self.document.pk}))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Document.objects.filter(pk=self.document.pk).exists())
+
+    def test_staff_cannot_manage_document_requirements_and_checklists(self):
+        self.client.force_login(self.staff)
+        manage_response = self.client.get(reverse("clients:document_checklist_manage"))
+        add_response = self.client.post(
+            reverse("clients:document_requirement_add"),
+            data={
+                "purpose": self.client_obj.application_purpose,
+                "name": "Staff custom doc",
+            },
+        )
+        edit_response = self.client.post(
+            reverse("clients:document_requirement_edit", kwargs={"pk": self.requirement.pk}),
+            data={
+                f"req-{self.requirement.pk}-custom_name": "Updated by staff",
+                f"req-{self.requirement.pk}-custom_name_pl": "",
+                f"req-{self.requirement.pk}-custom_name_en": "",
+                f"req-{self.requirement.pk}-custom_name_ru": "",
+            },
+        )
+        self.assertEqual(manage_response.status_code, 403)
+        self.assertEqual(add_response.status_code, 403)
+        self.assertEqual(edit_response.status_code, 403)
+
+    def test_manager_can_manage_document_requirements_and_checklists(self):
+        self.client.force_login(self.manager)
+        manage_response = self.client.get(reverse("clients:document_checklist_manage"))
+        add_response = self.client.post(
+            reverse("clients:document_requirement_add"),
+            data={
+                "purpose": self.client_obj.application_purpose,
+                "name": "Manager custom doc",
+            },
+        )
+        edit_response = self.client.post(
+            reverse("clients:document_requirement_edit", kwargs={"pk": self.requirement.pk}),
+            data={
+                f"req-{self.requirement.pk}-custom_name": "Updated by manager",
+                f"req-{self.requirement.pk}-custom_name_pl": "",
+                f"req-{self.requirement.pk}-custom_name_en": "",
+                f"req-{self.requirement.pk}-custom_name_ru": "",
+            },
+        )
+        self.assertEqual(manage_response.status_code, 200)
+        self.assertEqual(add_response.status_code, 302)
+        self.assertEqual(edit_response.status_code, 302)
 
     def test_staff_cannot_access_people_and_settings_management(self):
         self.client.force_login(self.staff)

--- a/clients/tests/test_roles_constants.py
+++ b/clients/tests/test_roles_constants.py
@@ -8,6 +8,8 @@ def test_required_role_constants_are_exported_and_non_empty():
         "CLIENT_EDIT_ROLES",
         "CLIENT_DELETE_ROLES",
         "CHECKLIST_MANAGE_ROLES",
+        "DOCUMENT_EDIT_ROLES",
+        "DOCUMENT_DELETE_ROLES",
     )
 
     for name in required:
@@ -15,3 +17,7 @@ def test_required_role_constants_are_exported_and_non_empty():
         value = getattr(roles, name)
         assert isinstance(value, tuple), f"{name} should be a tuple"
         assert value, f"{name} should not be empty"
+
+
+def test_checklist_manage_roles_are_restricted_to_admin_and_manager():
+    assert roles.CHECKLIST_MANAGE_ROLES == ("Admin", "Manager")

--- a/clients/tests/test_wniosek_stage10.py
+++ b/clients/tests/test_wniosek_stage10.py
@@ -20,7 +20,13 @@ class WniosekFlowStage10Tests(TestCase):
             password="pass",
             is_staff=True,
         )
+        self.manager = user_model.objects.create_user(
+            email="manager_wniosek@example.com",
+            password="pass",
+            is_staff=True,
+        )
         self.staff.groups.add(Group.objects.get(name="Staff"))
+        self.manager.groups.add(Group.objects.get(name="Manager"))
         self.client.login(email="staff_wniosek@example.com", password="pass")
         self.client_obj = Client.objects.create(
             first_name="Maria",
@@ -242,6 +248,7 @@ class WniosekFlowStage10Tests(TestCase):
             submission=submission,
             document_type="",
         )
+        self.client.force_login(self.manager)
 
         response = self.client.post(
             reverse(
@@ -276,6 +283,7 @@ class WniosekFlowStage10Tests(TestCase):
 
         attachment = WniosekAttachment.objects.get(submission__client=self.client_obj)
         submission_id = attachment.submission_id
+        self.client.force_login(self.manager)
 
         response = self.client.post(
             reverse(

--- a/clients/views/clients.py
+++ b/clients/views/clients.py
@@ -47,6 +47,7 @@ from clients.services.roles import (
     CHECKLIST_MANAGE_ROLES,
     CLIENT_DELETE_ROLES,
     CLIENT_EDIT_ROLES,
+    DOCUMENT_EDIT_ROLES,
     PEOPLE_ALLOWED_ROLES,
     PREDEFINED_ROLES,
     SETTINGS_ALLOWED_ROLES,
@@ -239,7 +240,7 @@ class ClientUpdateView(RoleRequiredMixin, UpdateView):
 
 
 class ClientDeleteView(RoleRequiredMixin, DeleteView):
-    allowed_roles = ["Admin", "Manager", "Staff"]
+    allowed_roles = list(CLIENT_DELETE_ROLES)
     model = Client
     template_name = "clients/client_confirm_delete.html"
     success_url = reverse_lazy("clients:client_list")
@@ -714,7 +715,7 @@ client_wsc_print_view = ClientWSCPrintView.as_view()
 client_document_print_view = ClientDocumentPrintView.as_view()
 
 
-@role_required_view(*CHECKLIST_MANAGE_ROLES)
+@role_required_view(*DOCUMENT_EDIT_ROLES)
 def client_document_print_confirm_view(request, pk, doc_type):
     if request.method != "POST":
         return redirect("clients:client_document_print", pk=pk, doc_type=doc_type)

--- a/clients/views/documents.py
+++ b/clients/views/documents.py
@@ -25,12 +25,12 @@ from clients.use_cases.documents import (
     verify_all_client_documents,
 )
 from clients.services.access import accessible_clients_queryset, accessible_documents_queryset
-from clients.services.roles import DOCUMENT_MUTATION_ROLES
+from clients.services.roles import DOCUMENT_DELETE_ROLES, DOCUMENT_EDIT_ROLES
 from clients.views.base import role_required_view, staff_required_view
 from legalize_site.utils.files import build_protected_file_response
 
 
-@role_required_view(*DOCUMENT_MUTATION_ROLES)
+@role_required_view(*DOCUMENT_EDIT_ROLES)
 def update_client_notes(request, pk):
     client = get_object_or_404(accessible_clients_queryset(request.user, Client.objects.all()), pk=pk)
     helper = ResponseHelper(request)
@@ -48,7 +48,7 @@ def update_client_notes(request, pk):
     return redirect("clients:client_list")
 
 
-@role_required_view(*DOCUMENT_MUTATION_ROLES)
+@role_required_view(*DOCUMENT_EDIT_ROLES)
 def add_document(request, client_id, doc_type):
     client = get_object_or_404(accessible_clients_queryset(request.user, Client.objects.all()), pk=client_id)
     document_type_display = client.get_document_name_by_code(doc_type)
@@ -106,7 +106,7 @@ def add_document(request, client_id, doc_type):
     )
 
 
-@role_required_view(*DOCUMENT_MUTATION_ROLES)
+@role_required_view(*DOCUMENT_EDIT_ROLES)
 def confirm_wezwanie_parse(request, doc_id):
     document = get_object_or_404(accessible_documents_queryset(request.user, Document.objects.all()), pk=doc_id)
     helper = ResponseHelper(request)
@@ -144,7 +144,7 @@ def confirm_wezwanie_parse(request, doc_id):
     return redirect("clients:client_detail", pk=document.client.id)
 
 
-@role_required_view(*DOCUMENT_MUTATION_ROLES)
+@role_required_view(*DOCUMENT_DELETE_ROLES)
 def document_delete(request, pk):
     document = get_object_or_404(accessible_documents_queryset(request.user, Document.objects.all()), pk=pk)
     client_id = document.client.id
@@ -162,7 +162,7 @@ def document_delete(request, pk):
     return redirect("clients:client_detail", pk=client_id)
 
 
-@role_required_view(*DOCUMENT_MUTATION_ROLES)
+@role_required_view(*DOCUMENT_DELETE_ROLES)
 def wniosek_attachment_delete(request, attachment_id):
     attachment = get_object_or_404(
         WniosekAttachment.objects.select_related("submission", "submission__client").filter(
@@ -187,7 +187,7 @@ def wniosek_attachment_delete(request, attachment_id):
     return redirect("clients:client_detail", pk=client_id)
 
 
-@role_required_view(*DOCUMENT_MUTATION_ROLES)
+@role_required_view(*DOCUMENT_EDIT_ROLES)
 def toggle_document_verification(request, doc_id):
     """Toggle verification status for a client document."""
 
@@ -216,7 +216,7 @@ def toggle_document_verification(request, doc_id):
     return redirect("clients:client_detail", pk=document.client.id)
 
 
-@role_required_view(*DOCUMENT_MUTATION_ROLES)
+@role_required_view(*DOCUMENT_EDIT_ROLES)
 def verify_all_documents(request, client_id):
     """Mark all uploaded documents for the client as verified."""
 

--- a/legalize_site/settings/base.py
+++ b/legalize_site/settings/base.py
@@ -45,7 +45,7 @@ def running_in_production() -> bool:
 IS_PRODUCTION = running_in_production()
 ENABLE_TRANSLATION_TOOLING = env_flag(
     "ENABLE_TRANSLATION_TOOLING",
-    "True",
+    "False",
 )
 AUTO_COMPILE_TRANSLATIONS_ON_STARTUP = env_flag("AUTO_COMPILE_TRANSLATIONS_ON_STARTUP", "False")
 

--- a/legalize_site/settings/development.py
+++ b/legalize_site/settings/development.py
@@ -8,6 +8,7 @@ from .base import env_flag
 from .base import *  # noqa: F403
 
 DEBUG = env_flag("DEBUG", "True")
+ENABLE_TRANSLATION_TOOLING = env_flag("ENABLE_TRANSLATION_TOOLING", "True")
 
 ALLOWED_HOSTS = [host for host in os.environ.get("ALLOWED_HOSTS", "").split(",") if host]
 ALLOWED_HOSTS.extend(["127.0.0.1", "localhost"])

--- a/legalize_site/settings/test.py
+++ b/legalize_site/settings/test.py
@@ -1,4 +1,17 @@
+import os
+
+os.environ.setdefault("ENABLE_TRANSLATION_TOOLING", "True")
+
 from .base import *
+
+ENABLE_TRANSLATION_TOOLING = True
+
+if "translations" not in INSTALLED_APPS:
+    INSTALLED_APPS.append("translations")
+
+if "translations.middleware.TranslationStudioMiddleware" not in MIDDLEWARE:
+    insert_at = MIDDLEWARE.index("allauth.account.middleware.AccountMiddleware")
+    MIDDLEWARE.insert(insert_at, "translations.middleware.TranslationStudioMiddleware")
 
 # Force in-memory SQLite for tests to ignore Railway's DATABASE_URL during build phase
 DATABASES = {

--- a/legalize_site/urls.py
+++ b/legalize_site/urls.py
@@ -22,11 +22,11 @@ urlpatterns = [
     path('cron/process-email-campaigns/', process_email_campaigns_cron, name='process_email_campaigns_cron'),
 ]
 
-if getattr(settings, "ENABLE_TRANSLATION_TOOLING", False) and 'rosetta' in settings.INSTALLED_APPS:
-    urlpatterns += [
-        path('rosetta/', include('rosetta.urls')),
-        path('studio/', include('translations.urls', namespace='translations')),
-    ]
+if getattr(settings, "ENABLE_TRANSLATION_TOOLING", False):
+    if 'rosetta' in settings.INSTALLED_APPS:
+        urlpatterns.append(path('rosetta/', include('rosetta.urls')))
+    if 'translations' in settings.INSTALLED_APPS:
+        urlpatterns.append(path('studio/', include('translations.urls', namespace='translations')))
 
 urlpatterns += i18n_patterns(
     path("accounts/signup/", SignupDisabledView.as_view(), name="account_signup"),

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -10,10 +10,10 @@ cmds = [
   "pip install -r requirements.txt"
 ]
 
+# Tests run in GitHub Actions; production build skips pytest.
 [phases.build]
 cmds = [
   "python manage.py compilemessages --ignore venv --ignore .venv",
-  "DJANGO_SETTINGS_MODULE=legalize_site.settings.test pytest --maxfail=1 -q",
   "python manage.py collectstatic --no-input"
 ]
 


### PR DESCRIPTION
### Motivation

- Remove a duplicate kwarg causing a SyntaxError in the email cleanup command and ensure email payload scrubbing works cleanly.  
- Tighten role-based permissions so delete and checklist management actions match policy (Staff can edit/upload/verify, but delete/checklist management is limited to Manager/Admin).  
- Make translation tooling off by default for production builds and decouple test/dev wiring so tests needing Translation Studio still run locally/CI.  

### Description

- Fixed `cleanup_email_logs` by removing the duplicate `recipient_emails` keyword (keep `recipient_emails="[]"`).  
- Introduced `DOCUMENT_EDIT_ROLES = ("Admin","Manager","Staff")` and `DOCUMENT_DELETE_ROLES = ("Admin","Manager")`, and set `CHECKLIST_MANAGE_ROLES = ("Admin","Manager")`, then updated views to use these constants (including `ClientDeleteView`, document delete endpoints and wniosek attachment delete), while keeping staff on edit actions.  
- Adjusted translation defaults by setting `ENABLE_TRANSLATION_TOOLING` default to `False` in `base.py`, enabling it in `development.py` and ensuring `test.py` explicitly enables and wires the `translations` app and middleware for the test suite; updated `urls.py` to include translation routes only when the corresponding apps are present.  
- Removed `pytest` execution from `build.sh` and `nixpacks.toml` with clear comments that tests run in CI, and added/updated tests that assert the new permission matrix for client/document deletion and checklist management.  

### Testing

- Commands executed: `python -m compileall .`, `DJANGO_SETTINGS_MODULE=legalize_site.settings.test python manage.py check`, `DJANGO_SETTINGS_MODULE=legalize_site.settings.test python manage.py makemigrations --check --dry-run`, and `DJANGO_SETTINGS_MODULE=legalize_site.settings.test pytest -q`, and all completed successfully with `pytest` reporting all tests passing (`290 passed`, environment-typical warnings observed).  
- Changed files (key list): `clients/management/commands/cleanup_email_logs.py`, `clients/services/roles.py`, `clients/views/clients.py`, `clients/views/documents.py`, `clients/tests/test_role_permissions_stage14.py`, `clients/tests/test_roles_constants.py`, `clients/tests/test_wniosek_stage10.py`, `legalize_site/settings/base.py`, `legalize_site/settings/development.py`, `legalize_site/settings/test.py`, `legalize_site/urls.py`, `build.sh`, and `nixpacks.toml`.  
- Tests added/changed: permission tests and constants checks in `clients/tests/test_role_permissions_stage14.py`, `clients/tests/test_roles_constants.py`, and updates in `clients/tests/test_wniosek_stage10.py` to reflect new delete-role behavior.  
- Remaining risks: Django system-check warnings remain about default `SECRET_KEY`/FERNET_KEYS and missing external binaries (OCR/pg_dump) which are environment/deployment concerns but pre-existing, and production deployments must explicitly enable `ENABLE_TRANSLATION_TOOLING` if Translation Studio is required in that environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed295efe4c832ebf24ad36eca3b010)