### PR TITLE
Clarify production build test policy in build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,5 +18,5 @@ pip install -r requirements.txt
 # Skip translating files shipped in the virtualenv to avoid permission errors
 python manage.py compilemessages --ignore "venv" --ignore ".venv"
 
-# Tests run in GitHub Actions; production build skips pytest for faster deploys.
+# pytest is intentionally omitted from production build; tests run in GitHub Actions only.
 python manage.py collectstatic --no-input

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -10,7 +10,7 @@ cmds = [
   "pip install -r requirements.txt"
 ]
 
-# Tests run in GitHub Actions; production build skips pytest.
+# pytest is intentionally omitted from production build; tests run in GitHub Actions only.
 [phases.build]
 cmds = [
   "python manage.py compilemessages --ignore venv --ignore .venv",


### PR DESCRIPTION
### Motivation
- Remove ambiguity in build scripts about where tests run by explicitly documenting that `pytest` is intentionally omitted from production builds and is executed in CI only.

### Description
- Update comments in `build.sh` and `nixpacks.toml` to state `pytest` is intentionally omitted from production build; tests run in GitHub Actions only, with no functional code changes; files changed: `build.sh`, `nixpacks.toml`, and no tests were added or modified.

### Testing
- Ran `python -m compileall .` (success), `DJANGO_SETTINGS_MODULE=legalize_site.settings.test python manage.py check` (success with non-blocking environment warnings), `DJANGO_SETTINGS_MODULE=legalize_site.settings.test python manage.py makemigrations --check --dry-run` (no changes), and `DJANGO_SETTINGS_MODULE=legalize_site.settings.test pytest -q` (collection failed in this environment with `AppRegistryNotReady` because `pytest-django`/test collection integration is not active), remaining risks: full pytest suite could not be executed here and `manage.py check` reports development warnings about fallback `SECRET_KEY`, derived `FERNET_KEYS`, and missing OCR/backup binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0909faf8832e8d2a14e5160a2075)