### PR TITLE
Harden CRM staff permissions and dashboard access

### DIFF
--- a/clients/forms.py
+++ b/clients/forms.py
@@ -142,9 +142,6 @@ class StaffUserCreateForm(forms.ModelForm):
             self.add_error("password2", "Passwords do not match.")
         return cleaned
 
-    def clean_is_superuser(self):
-        return False
-
     def save(self, commit=True):
         user = super().save(commit=False)
         user.set_password(self.cleaned_data["password1"])

--- a/clients/services/permissions.py
+++ b/clients/services/permissions.py
@@ -24,6 +24,18 @@ EMPLOYEE_PERMISSION_FIELDS = {
     "can_run_ocr_review",
 }
 
+READONLY_BLOCKED_PERMISSION_FIELDS = {
+    "can_manage_payments",
+    "can_send_custom_email",
+    "can_send_mass_email",
+    "can_export_clients",
+    "can_delete_clients",
+    "can_delete_documents",
+    "can_manage_checklists",
+    "can_manage_staff_tasks",
+    "can_run_ocr_review",
+}
+
 
 def has_employee_permission(user, permission_name: str) -> bool:
     if not getattr(user, "is_authenticated", False):
@@ -35,6 +47,8 @@ def has_employee_permission(user, permission_name: str) -> bool:
     if permission_name not in EMPLOYEE_PERMISSION_FIELDS:
         return False
     if not is_internal_staff_user(user):
+        return False
+    if user_has_any_role(user, "ReadOnly") and permission_name in READONLY_BLOCKED_PERMISSION_FIELDS:
         return False
 
     permission_object = getattr(user, "employee_permission", None)

--- a/clients/signals.py
+++ b/clients/signals.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 def ensure_employee_permissions_for_staff(sender, instance, created, **kwargs):
     if not getattr(instance, "is_staff", False):
         return
-    if created:
-        EmployeePermission.objects.get_or_create(user=instance)
+    EmployeePermission.objects.get_or_create(user=instance)
 
 
 

--- a/clients/templates/clients/staff_manage.html
+++ b/clients/templates/clients/staff_manage.html
@@ -94,10 +94,6 @@
                   <input class="form-check-input" type="checkbox" name="{{ form.is_staff.html_name }}" value="on" form="update-user-{{ staff_user.id }}" {% if staff_user.is_staff %}checked{% endif %}>
                   <label class="form-check-label">Staff</label>
                 </div>
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" name="{{ form.is_superuser.html_name }}" value="on" form="update-user-{{ staff_user.id }}" {% if staff_user.is_superuser %}checked{% endif %}>
-                  <label class="form-check-label">Superuser</label>
-                </div>
                 <div class="form-check mb-2">
                   <input class="form-check-input" type="checkbox" name="{{ form.is_active.html_name }}" value="on" form="update-user-{{ staff_user.id }}" {% if staff_user.is_active %}checked{% endif %}>
                   <label class="form-check-label">Active</label>

--- a/clients/tests/test_dashboard_permissions.py
+++ b/clients/tests/test_dashboard_permissions.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import TestCase
+from django.urls import reverse
+
+from clients.services.roles import ensure_predefined_roles
+
+
+class DashboardPermissionTests(TestCase):
+    def setUp(self):
+        ensure_predefined_roles()
+        user_model = get_user_model()
+
+        self.staff = user_model.objects.create_user(email="dash-staff@example.com", password="pass", is_staff=True)
+        self.staff.groups.add(Group.objects.get(name="Staff"))
+
+        self.manager = user_model.objects.create_user(email="dash-manager@example.com", password="pass", is_staff=True)
+        self.manager.groups.add(Group.objects.get(name="Manager"))
+
+        self.admin = user_model.objects.create_user(email="dash-admin@example.com", password="pass", is_staff=True)
+        self.admin.groups.add(Group.objects.get(name="Admin"))
+
+    def test_staff_cannot_access_admin_dashboard_by_default(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("clients:admin_dashboard"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_staff_with_can_run_ocr_review_still_cannot_access_admin_dashboard(self):
+        self.staff.employee_permission.can_run_ocr_review = True
+        self.staff.employee_permission.save(update_fields=["can_run_ocr_review", "updated_at"])
+
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("clients:admin_dashboard"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_manager_can_access_admin_dashboard(self):
+        self.client.force_login(self.manager)
+        response = self.client.get(reverse("clients:admin_dashboard"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_can_access_admin_dashboard(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(reverse("clients:admin_dashboard"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_staff_without_can_view_reports_cannot_access_metrics(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("clients:metrics_dashboard"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_staff_with_can_view_reports_can_access_metrics(self):
+        self.staff.employee_permission.can_view_reports = True
+        self.staff.employee_permission.save(update_fields=["can_view_reports", "updated_at"])
+
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("clients:metrics_dashboard"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_manager_can_access_metrics(self):
+        self.client.force_login(self.manager)
+        response = self.client.get(reverse("clients:metrics_dashboard"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_can_access_metrics(self):
+        self.client.force_login(self.admin)
+        response = self.client.get(reverse("clients:metrics_dashboard"))
+        self.assertEqual(response.status_code, 200)

--- a/clients/tests/test_employee_permissions.py
+++ b/clients/tests/test_employee_permissions.py
@@ -22,6 +22,8 @@ class EmployeePermissionsTests(TestCase):
 
         self.admin = user_model.objects.create_user(email="admin-perm@example.com", password="pass", is_staff=True)
         self.admin.groups.add(Group.objects.get(name="Admin"))
+        self.read_only = user_model.objects.create_user(email="readonly-perm@example.com", password="pass", is_staff=True)
+        self.read_only.groups.add(Group.objects.get(name="ReadOnly"))
 
         self.client_obj = Client.objects.create(
             first_name="Jan",
@@ -39,6 +41,21 @@ class EmployeePermissionsTests(TestCase):
 
     def test_employee_permission_is_auto_created_for_staff_user(self):
         self.assertTrue(EmployeePermission.objects.filter(user=self.staff).exists())
+
+    def test_non_staff_user_does_not_get_employee_permission(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(email="plain-user@example.com", password="pass", is_staff=False)
+        self.assertFalse(EmployeePermission.objects.filter(user=user).exists())
+
+    def test_employee_permission_created_when_user_becomes_staff(self):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(email="promoted-user@example.com", password="pass", is_staff=False)
+        self.assertFalse(EmployeePermission.objects.filter(user=user).exists())
+
+        user.is_staff = True
+        user.save(update_fields=["is_staff"])
+
+        self.assertTrue(EmployeePermission.objects.filter(user=user).exists())
 
     def test_has_employee_permission_rules(self):
         self.assertFalse(has_employee_permission(AnonymousUser(), "can_delete_clients"))
@@ -92,3 +109,48 @@ class EmployeePermissionsTests(TestCase):
             },
         )
         self.assertEqual(response.status_code, 302)
+
+    def test_readonly_with_can_delete_clients_still_cannot_delete_client(self):
+        perms = self.read_only.employee_permission
+        perms.can_delete_clients = True
+        perms.save(update_fields=["can_delete_clients", "updated_at"])
+
+        self.client.force_login(self.read_only)
+        response = self.client.post(reverse("clients:client_delete", kwargs={"pk": self.client_obj.pk}))
+        self.assertEqual(response.status_code, 403)
+
+    def test_readonly_with_can_delete_documents_still_cannot_delete_document(self):
+        perms = self.read_only.employee_permission
+        perms.can_delete_documents = True
+        perms.save(update_fields=["can_delete_documents", "updated_at"])
+
+        self.client.force_login(self.read_only)
+        response = self.client.post(reverse("clients:document_delete", kwargs={"pk": self.document.pk}))
+        self.assertEqual(response.status_code, 403)
+
+    def test_readonly_with_can_export_clients_still_cannot_export(self):
+        perms = self.read_only.employee_permission
+        perms.can_export_clients = True
+        perms.save(update_fields=["can_export_clients", "updated_at"])
+
+        self.client.force_login(self.read_only)
+        response = self.client.get(reverse("clients:client_export_zip", kwargs={"pk": self.client_obj.pk}))
+        self.assertEqual(response.status_code, 403)
+
+    def test_readonly_with_can_send_mass_email_still_cannot_send_mass_email(self):
+        perms = self.read_only.employee_permission
+        perms.can_send_mass_email = True
+        perms.save(update_fields=["can_send_mass_email", "updated_at"])
+
+        self.client.force_login(self.read_only)
+        response = self.client.post(reverse("clients:mass_email"), data={"subject": "x", "message": "y"})
+        self.assertEqual(response.status_code, 403)
+
+    def test_readonly_with_can_view_reports_can_access_metrics(self):
+        perms = self.read_only.employee_permission
+        perms.can_view_reports = True
+        perms.save(update_fields=["can_view_reports", "updated_at"])
+
+        self.client.force_login(self.read_only)
+        response = self.client.get(reverse("clients:metrics_dashboard"))
+        self.assertEqual(response.status_code, 200)

--- a/clients/tests/test_metrics_and_responses_stage8.py
+++ b/clients/tests/test_metrics_and_responses_stage8.py
@@ -4,12 +4,14 @@ import json
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
 from clients.models import Client, Document, Payment
+from clients.services.roles import ensure_predefined_roles
 from clients.services.responses import NO_STORE_HEADER, ResponseHelper, apply_no_store
 from clients.constants import DocumentType
 
@@ -61,8 +63,12 @@ class ResponseHelpersStage8Tests(TestCase):
 
 class MetricsDashboardStage8Tests(TestCase):
     def setUp(self):
+        ensure_predefined_roles()
         user_model = get_user_model()
         self.staff = user_model.objects.create_user(email="metrics_staff@example.com", password="pass", is_staff=True)
+        self.staff.groups.add(Group.objects.get(name="Staff"))
+        self.staff.employee_permission.can_view_reports = True
+        self.staff.employee_permission.save(update_fields=["can_view_reports", "updated_at"])
         self.client.login(email="metrics_staff@example.com", password="pass")
 
         today = timezone.localdate()

--- a/clients/views/admin_dashboard.py
+++ b/clients/views/admin_dashboard.py
@@ -19,7 +19,7 @@ from clients.models import (
     Reminder,
     StaffTask,
 )
-from clients.services.roles import ADMIN_PANEL_ALLOWED_ROLES
+from clients.services.roles import SETTINGS_ALLOWED_ROLES
 from clients.views.base import RoleOrFeatureRequiredMixin
 from legalize_site.runtime import collect_runtime_dependency_statuses
 
@@ -90,8 +90,7 @@ class AdminDashboardView(RoleOrFeatureRequiredMixin, TemplateView):
     """Global health and status dashboard for administrators."""
 
     template_name = "clients/admin_dashboard.html"
-    allowed_roles = list(ADMIN_PANEL_ALLOWED_ROLES)
-    required_permission_name = "can_run_ocr_review"
+    allowed_roles = list(SETTINGS_ALLOWED_ROLES)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/clients/views/clients.py
+++ b/clients/views/clients.py
@@ -652,6 +652,8 @@ def staff_manage_view(request):
             staff_user = get_object_or_404(user_model, pk=user_id, is_staff=True)
             form = StaffUserUpdateForm(request.POST, instance=staff_user, prefix=f"user-{staff_user.id}")
             if form.is_valid():
+                # TODO(audit): add an organization-level audit/event log for employee permission changes
+                # (actor=request.user, target=staff_user, changed_fields only, no PII) once such model exists.
                 form.save()
                 messages.success(request, _("Сотрудник обновлён."))
                 return redirect("clients:staff_manage")

--- a/clients/views/metrics.py
+++ b/clients/views/metrics.py
@@ -4,13 +4,13 @@ from django.utils import timezone
 from datetime import timedelta
 
 from clients.models import Client, Document, Payment
-from clients.services.roles import ADMIN_PANEL_ALLOWED_ROLES
+from clients.services.roles import SETTINGS_ALLOWED_ROLES
 from clients.views.base import RoleOrFeatureRequiredMixin
 from django.views.generic import TemplateView
 
 class MetricsDashboardView(RoleOrFeatureRequiredMixin, TemplateView):
     template_name = 'clients/metrics_dashboard.html'
-    allowed_roles = list(ADMIN_PANEL_ALLOWED_ROLES)
+    allowed_roles = list(SETTINGS_ALLOWED_ROLES)
     required_permission_name = "can_view_reports"
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
### Motivation
- Prevent accidental or unauthorized elevation of internal users via the CRM staff page by removing superuser toggles and tightening permission checks.
- Ensure `EmployeePermission` objects exist for staff users reliably and prevent non-staff from receiving them.
- Narrow access to admin/metrics dashboards to roles and explicit feature flags to reduce attack surface.

### Description
- Removed `is_superuser` checkbox/label from `clients/templates/clients/staff_manage.html` and deleted dead `StaffUserCreateForm.clean_is_superuser()` from `clients/forms.py` so superuser management remains only in Django admin/CLI.
- Added `READONLY_BLOCKED_PERMISSION_FIELDS` and a check in `clients/services/permissions.py` so users with role `ReadOnly` cannot gain mutation/destructive feature permissions even if checkboxes are toggled (they may only have `can_view_reports` per chosen policy).
- Changed `clients/signals.py` so `EmployeePermission.objects.get_or_create(user=...)` runs for any save when `user.is_staff` is true (no `created=True` restriction); non-staff users are unaffected.
- Restricted `AdminDashboardView` to settings roles (`Admin`/`Manager`) and removed the `can_run_ocr_review` fallback in `clients/views/admin_dashboard.py`.
- Adjusted `MetricsDashboardView` to require `Admin`/`Manager` roles or `can_view_reports` for staff by role/feature in `clients/views/metrics.py`.
- Added a `TODO` comment in `clients/views/clients.py` to log employee permission changes to an organization-level audit log when a suitable mechanism exists (no ad-hoc audit integration added).
- Tests and small test-suite adjustments added: new dashboard and permission tests and an update to an existing metrics test to reflect the stricter access model.

### Testing
- Ran Django system checks: `DJANGO_SETTINGS_MODULE=legalize_site.settings.test python manage.py check` (succeeded with unrelated warnings).
- Ran migrations dry-run: `DJANGO_SETTINGS_MODULE=legalize_site.settings.test python manage.py makemigrations --check --dry-run` (no changes detected).
- Ran the full test subset: `DJANGO_SETTINGS_MODULE=legalize_site.settings.test python manage.py test clients.tests.test_employee_permissions clients.tests.test_dashboard_permissions clients.tests.test_metrics_and_responses_stage8 -v 2` and all selected tests passed.
- Attempted `pytest -q` which failed during collection in this environment due to pytest-django/plugin configuration (`Unknown config option: DJANGO_SETTINGS_MODULE`) not related to this patch.
- Ran `ruff check .` which failed on pre-existing repo-wide lint issues unrelated to changes introduced by this PR.

Changed files: `clients/templates/clients/staff_manage.html`, `clients/forms.py`, `clients/services/permissions.py`, `clients/signals.py`, `clients/views/admin_dashboard.py`, `clients/views/metrics.py`, `clients/views/clients.py`, `clients/tests/test_employee_permissions.py`, `clients/tests/test_metrics_and_responses_stage8.py`, `clients/tests/test_dashboard_permissions.py`.

Tests added/changed: permission and dashboard tests in `clients/tests/test_employee_permissions.py` and new `clients/tests/test_dashboard_permissions.py`, plus a setup tweak in `clients/tests/test_metrics_and_responses_stage8.py`.

Remaining risks: full `pytest -q` and `ruff` remain blocked by environment/project-wide configuration and lint debt not introduced by this PR; audit logging left as a TODO until a suitable non-client-scoped audit mechanism is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee24126028832eb52c1454dd5236b8)