### PR TITLE
Set default Django storage backend when WhiteNoise is enabled

### DIFF
--- a/legalize_site/settings/base.py
+++ b/legalize_site/settings/base.py
@@ -324,7 +324,10 @@ USE_TZ = True
 # --- СТАТИКА И МЕДИА (WHITENOISE) ---
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 if WHITENOISE_AVAILABLE:
-    STORAGES = {"staticfiles": {"BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"}}
+    STORAGES = {
+        "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+        "staticfiles": {"BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"},
+    }
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = os.environ.get("MEDIA_ROOT", str(BASE_DIR / "media"))


### PR DESCRIPTION
### Motivation
- Some environments only defined `STORAGES` for `staticfiles`, which led to `InvalidStorageError: Could not find config for 'default' in settings.STORAGES` when code accessed the default file storage (for example during document existence checks).

### Description
- When `WHITENOISE_AVAILABLE` is true, add a `STORAGES["default"]` entry using `django.core.files.storage.FileSystemStorage` alongside the existing WhiteNoise `staticfiles` backend in `legalize_site/settings/base.py` to ensure a configured default storage backend.

### Testing
- Ran `pytest -q legalize_site/tests/test_production_settings.py::ProductionSettingsTests::test_database_media_storage_configures_default_storage_backend` but it failed to start due to `pytest.ini` injecting unsupported coverage args in this environment, so the run could not complete.
- Ran `pytest -q -o addopts='' legalize_site/tests/test_production_settings.py::ProductionSettingsTests::test_database_media_storage_configures_default_storage_backend` which errored because Django settings were not configured in the test invocation (`DJANGO_SETTINGS_MODULE` not set), so the test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21545de70832ea2c9152d3cca9a1a)